### PR TITLE
ataxx: Version `0.2.0`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
 
-      - run: cargo clippy --verbose
-      - run: cargo build --verbose
-      - run: cargo test --verbose
+      - run: cargo clippy --verbose -- -D warnings
+      - run: cargo build --verbose -- -D warnings
+      - run: cargo test --verbose -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,12 @@ on:
   - pull_request
 
 env:
-  RUSTFLAGS: -D warnings   # treat warnings as errors
-  CARGO_TERM_COLOR: always # use colors when printing
+  # treat warnings as errors
+  RUSTFLAGS:    -D warnings
+  RUSTDOCFLAGS: -D warnings
+
+  # use colors when printing
+  CARGO_TERM_COLOR: always
 
 jobs:
   build_and_test:
@@ -22,6 +26,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      # update rust to latest stable version
       - run: rustup update stable && rustup default stable
 
       - run: cargo clippy # look for lint errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   - pull_request
 
 env:
+  RUSTFLAGS: -D warnings # treat warnings as errors
   CARGO_TERM_COLOR: always
 
 jobs:
@@ -23,6 +24,6 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
 
-      - run: cargo clippy --verbose -- -D warnings
-      - run: cargo rustc --verbose -- -D warnings
-      - run: cargo test --verbose -- -D warnings
+      - run: cargo clippy
+      - run: cargo build
+      - run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,8 @@ on:
   - pull_request
 
 env:
-  RUSTFLAGS: -D warnings # treat warnings as errors
-  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -D warnings   # treat warnings as errors
+  CARGO_TERM_COLOR: always # use colors when printing
 
 jobs:
   build_and_test:
@@ -24,6 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup update stable && rustup default stable
 
-      - run: cargo clippy
-      - run: cargo build
-      - run: cargo test
+      - run: cargo clippy # look for lint errors
+      - run: cargo build  # look for build errors
+      - run: cargo test   # look for test errors
+      - run: cargo doc    # look for bad documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,5 @@ jobs:
       - run: rustup update stable && rustup default stable
 
       - run: cargo clippy --verbose -- -D warnings
-      - run: cargo build --verbose -- -D warnings
+      - run: cargo rustc --verbose -- -D warnings
       - run: cargo test --verbose -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,3 +2,8 @@
 members = [
     "ataxx"
 ]
+
+[profile.release]
+opt-level = 3
+codegen-units = 1
+lto = true

--- a/ataxx/Cargo.toml
+++ b/ataxx/Cargo.toml
@@ -12,6 +12,7 @@ keywords = ["ataxx"]
 categories = ["games"]
 
 [dependencies]
+thiserror = "1.0"
 num-traits = "0.2"
 num-derive = "0.4"
 strum = "0.26"

--- a/ataxx/README.md
+++ b/ataxx/README.md
@@ -5,29 +5,60 @@
 
 <samp>ataxx</samp> is a Rust package which provides various functionalities to deal with the [Ataxx](https://en.wikipedia.org/wiki/Ataxx) game in pure Rust. It provides various functionalities like board representation, move generation, UAI client creation, etc.
 
-```rs
+```rust
+use ataxx::*;
 use std::str::FromStr;
-use ataxx::{ Board, Square, Move };
 
 fn main() {
-    // Parse Ataxx Board from FEN
-    let mut board = Board::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
-    println!("{}" board);
+    let position = Position::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
 
-    // Make moves on the Board
-    board.make_move(Move::new_single(Square::F1));
-    println!("{}", board);
-
-    // Undo moves from the Board
-    board.undo_move();
-    println!("{}", board);
+    println!("{}\n", position);
+    println!("perft(6): {}", perft(position, 6));
 }
+
+// An implementation of the standard perft function which walks the move
+// generation tree of strictly legal moves to count all the leaf nodes of a
+// certain depth. Nodes are only counted at the end after the last make-move.
+// Thus "higher" terminal nodes (e.g. mate or stalemate) are not counted,
+// instead the number of move paths of a certain depth. Perft ignores draws by
+// repetition or by the fifty-move rule.
+//
+// A more advanced implementation of perft is available as `ataxx::perft`.
+fn perft(position: Position, depth: u8) -> u64 {
+    // perft(0) = 1
+    if depth == 0 {
+        return 1;
+    }
+
+    // perft(1) = number of moves in the position
+    if depth == 1 {
+        // Counting the number of moves in a Position is provided as a separate
+        // function which is faster than the simple `generate_moves.len()`.
+        return position.count_moves() as u64;
+    }
+
+    let mut nodes: u64 = 0;
+    let movelist = position.generate_moves();
+
+    // MoveList implements IntoIterator, so it can be directly used in a for loop.
+    for m in movelist {
+        // Providing false as the value of the `UPDATE_HASH` template constant
+        // disables updating the position's Hash in `after_move` which makes
+        // it faster than `after_move::<true>()` and can be done here since we
+        // don't use the position's Hash anywhere.
+        let new_position = position.after_move::<false>(m);
+        nodes += perft(new_position, depth - 1);
+    }
+
+    nodes
+}
+
 ```
 
 ## Features
-- Fast Board representation and Move generation using BitBoards.
-- Types for various features of Ataxx, including `Board`, `Position`, `Move`, `Square`, `Color`, etc.
-- Support for semi-unique hashing of Ataxx positions for hash tables.
-- Parsing `Position` and `Board` from FEN strings.
+- Fast Board representation and Move generation, resulting a perft faster than [<samp>libataxx</samp>](https://github.com/kz04px/libataxx).
+- Types for various features of Ataxx, including `Position`, `Move`, `Square`, `Piece`, etc.
+- Support for semi-unique hashing of Ataxx positions for hash tables, which is faster yet as strong as zobrist hashing.
+- Parsing a FEN string into a `Position`.
 
 Refer to the [documentation](https://docs.rs/ataxx) for a full in depth list of features and functions.

--- a/ataxx/src/bitboard.rs
+++ b/ataxx/src/bitboard.rs
@@ -44,7 +44,7 @@ use crate::{File, Rank, Square};
 /// assert_eq!(!x, BitBoard::UNIVERSE - x); // Complement
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, FromPrimitive)]
-pub struct BitBoard(u64);
+pub struct BitBoard(pub u64);
 
 /// bitboard is a macro which allows creation of BitBoard values from their
 /// graphical representation with (.)s and (X)s inside the macro call.

--- a/ataxx/src/bitboard.rs
+++ b/ataxx/src/bitboard.rs
@@ -44,7 +44,7 @@ use crate::{File, Rank, Square};
 /// assert_eq!(!x, BitBoard::UNIVERSE - x); // Complement
 /// ```
 #[derive(Copy, Clone, PartialEq, Eq, FromPrimitive)]
-pub struct BitBoard(pub u64);
+pub struct BitBoard(u64);
 
 /// bitboard is a macro which allows creation of BitBoard values from their
 /// graphical representation with (.)s and (X)s inside the macro call.
@@ -560,6 +560,12 @@ impl BitBoard {
     /// ```
     pub const fn double(square: Square) -> BitBoard {
         BitBoard::DOUBLES[square as usize]
+    }
+}
+
+impl From<BitBoard> for u64 {
+    fn from(value: BitBoard) -> Self {
+        value.0
     }
 }
 

--- a/ataxx/src/bitboard.rs
+++ b/ataxx/src/bitboard.rs
@@ -361,7 +361,7 @@ impl BitBoard {
     /// ```
     #[inline(always)]
     pub fn lsb(self) -> Square {
-        Square::try_from(self.0.trailing_zeros()).unwrap()
+        Square::unsafe_from(self.0.trailing_zeros())
     }
 
     /// get_msb returns the most significant Square from the BitBoard.
@@ -372,7 +372,7 @@ impl BitBoard {
     /// ```
     #[inline(always)]
     pub fn msb(self) -> Square {
-        Square::try_from(63 - self.0.leading_zeros()).unwrap()
+        Square::unsafe_from(63 - self.0.leading_zeros())
     }
 
     pub fn singles(self) -> BitBoard {

--- a/ataxx/src/bitboard.rs
+++ b/ataxx/src/bitboard.rs
@@ -374,6 +374,11 @@ impl BitBoard {
     pub fn msb(self) -> Square {
         Square::try_from(63 - self.0.leading_zeros()).unwrap()
     }
+
+    pub fn singles(self) -> BitBoard {
+        let bar = self | self.east() | self.west();
+        bar | bar.north() | bar.south()
+    }
 }
 
 // Iterator trait allows BitBoard to be used in a for loop.

--- a/ataxx/src/board.rs
+++ b/ataxx/src/board.rs
@@ -193,9 +193,9 @@ impl Position {
     ///     X . . . . . .
     /// });
     /// ```
-    pub fn put(&mut self, sq: Square, color: Piece) {
-        debug_assert_ne!(color, Piece::None);
-        self.bitboards[color as usize].insert(sq);
+    pub fn put(&mut self, sq: Square, piece: Piece) {
+        debug_assert_ne!(piece, Piece::None);
+        self.bitboards[piece as usize].insert(sq);
     }
 
     /// at returns the Piece of the piece present on the given Square.
@@ -234,8 +234,8 @@ impl Position {
     /// );
     /// assert_eq!(position.bitboard(Piece::White), BitBoard::UNIVERSE);
     /// ```
-    pub const fn bitboard(&self, color: Piece) -> BitBoard {
-        self.bitboards[color as usize]
+    pub const fn bitboard(&self, piece: Piece) -> BitBoard {
+        self.bitboards[piece as usize]
     }
 }
 
@@ -521,7 +521,7 @@ pub enum PositionParseError {
     #[error("a jump value was too long and overshot")]
     JumpTooLong,
 
-    #[error("invalid color identifier '{0}'")]
+    #[error("invalid piece identifier '{0}'")]
     InvalidPieceIdent(char),
     #[error("insufficient data to fill the entire {0} file")]
     FileDataIncomplete(File),

--- a/ataxx/src/board.rs
+++ b/ataxx/src/board.rs
@@ -166,28 +166,12 @@ impl Board {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum BoardParseError {
-    BadPosition(PositionParseError),
-    BadMoveCount(ParseIntError),
-}
-
-/// Given a [PositionParseError] which was encountered while trying to parse the
-/// Position part of the FEN string, it returns a [BoardParseError::BadPosition]
-/// which wraps the given [PositionParseError].
-impl From<PositionParseError> for BoardParseError {
-    fn from(value: PositionParseError) -> Self {
-        Self::BadPosition(value)
-    }
-}
-
-/// Given a [ParseIntError] which was encountered while trying to parse the
-/// move count in the FEN string, it returns a [BoardParseError::BadMoveCount]
-/// which wraps the given [ParseIntError].
-impl From<ParseIntError> for BoardParseError {
-    fn from(value: ParseIntError) -> Self {
-        Self::BadMoveCount(value)
-    }
+    #[error("{0}")]
+    BadPosition(#[from] PositionParseError),
+    #[error("bad move count string \"{0}\"")]
+    BadMoveCount(#[from] ParseIntError),
 }
 
 impl FromStr for Board {

--- a/ataxx/src/color.rs
+++ b/ataxx/src/color.rs
@@ -18,6 +18,8 @@ use std::str::FromStr;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 
+use thiserror::Error;
+
 use crate::type_macros;
 
 /// Color represents all the possible colors that an ataxx piece can have,
@@ -60,10 +62,12 @@ impl ops::Not for Color {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum ColorParseError {
+    #[error("color identifier string has more than 1 character")]
     StringTooLong,
-    StringFormatInvalid,
+    #[error("unknown color identifier '{0}'")]
+    StringFormatInvalid(String),
 }
 
 impl fmt::Display for Color {
@@ -105,7 +109,7 @@ impl FromStr for Color {
         match s {
             "x" | "X" | "b" | "B" => Ok(Color::Black),
             "o" | "O" | "w" | "W" => Ok(Color::White),
-            _ => Err(ColorParseError::StringFormatInvalid),
+            _ => Err(ColorParseError::StringFormatInvalid(s.to_string())),
         }
     }
 }

--- a/ataxx/src/hash.rs
+++ b/ataxx/src/hash.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::fmt;
+use std::{fmt, ops};
 
 use crate::{BitBoard, Piece};
 
@@ -24,7 +24,9 @@ pub struct Hash(pub u64);
 impl Hash {
     /// new creates a new Hash from the given black and white piece BitBoards.
     /// This function is used in the backend by Position, and it is usually
-    /// unnecessary for it to be used explicitly by end-users.
+    /// unnecessary for it to be used explicitly by end-users. new doesn't take
+    /// the blocker configuration into account since that remains unchanged
+    /// throughout an ataxx game.
     pub fn new(black: BitBoard, white: BitBoard, stm: Piece) -> Hash {
         let a = black.0;
         let b = white.0;
@@ -58,6 +60,15 @@ impl Hash {
         } else {
             Hash(hash)
         }
+    }
+}
+
+impl ops::Not for Hash {
+    type Output = Self;
+
+    /// Not operator (!) switches the side to move for the Hash.
+    fn not(self) -> Self::Output {
+        Hash(!self.0)
     }
 }
 

--- a/ataxx/src/hash.rs
+++ b/ataxx/src/hash.rs
@@ -19,17 +19,20 @@ use crate::{BitBoard, Piece};
 /// check for Position equality. Some properties of a Hash include determinism,
 /// uniform distribution, avalanche effect, and collision resistance.
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
-pub struct Hash(pub u64);
+pub struct Hash(u64);
 
 impl Hash {
+    /// ZERO represents a usable zero or null Hash value.
+    pub const ZERO: Hash = Hash(0);
+
     /// new creates a new Hash from the given black and white piece BitBoards.
     /// This function is used in the backend by Position, and it is usually
     /// unnecessary for it to be used explicitly by end-users. new doesn't take
     /// the blocker configuration into account since that remains unchanged
     /// throughout an ataxx game.
     pub fn new(black: BitBoard, white: BitBoard, stm: Piece) -> Hash {
-        let a = black.0;
-        let b = white.0;
+        let a = black.into();
+        let b = white.into();
 
         // Currently, an 2^-63-almost delta universal hash function, based on
         // https://eprint.iacr.org/2011/116.pdf by Long Hoang Nguyen and Andrew
@@ -60,6 +63,12 @@ impl Hash {
         } else {
             Hash(hash)
         }
+    }
+}
+
+impl From<Hash> for u64 {
+    fn from(value: Hash) -> Self {
+        value.0
     }
 }
 

--- a/ataxx/src/hash.rs
+++ b/ataxx/src/hash.rs
@@ -13,7 +13,7 @@
 
 use std::fmt;
 
-use crate::{BitBoard, Color};
+use crate::{BitBoard, Piece};
 
 /// Hash represents the semi-unique checksum of a Position used to efficiently
 /// check for Position equality. Some properties of a Hash include determinism,
@@ -25,7 +25,7 @@ impl Hash {
     /// new creates a new Hash from the given white and black piece BitBoards.
     /// This function is used in the backend by Position, and it is usually
     /// unnecessary for it to be used explicitly by end-users.
-    pub fn new(white: BitBoard, black: BitBoard, stm: Color) -> Hash {
+    pub fn new(white: BitBoard, black: BitBoard, stm: Piece) -> Hash {
         let a = white.0;
         let b = black.0;
 
@@ -51,9 +51,9 @@ impl Hash {
             .wrapping_add(part_3 as u64)
             .wrapping_add(part_4 as u64);
 
-        // The Hash is bitwise complemented if the given Color is Black. Therefore,
+        // The Hash is bitwise complemented if the given Piece is Black. Therefore,
         // if two Positions only differ in side to move, `a.Hash == !b.Hash`.
-        if stm == Color::Black {
+        if stm == Piece::Black {
             Hash(!hash)
         } else {
             Hash(hash)

--- a/ataxx/src/hash.rs
+++ b/ataxx/src/hash.rs
@@ -22,12 +22,12 @@ use crate::{BitBoard, Piece};
 pub struct Hash(pub u64);
 
 impl Hash {
-    /// new creates a new Hash from the given white and black piece BitBoards.
+    /// new creates a new Hash from the given black and white piece BitBoards.
     /// This function is used in the backend by Position, and it is usually
     /// unnecessary for it to be used explicitly by end-users.
-    pub fn new(white: BitBoard, black: BitBoard, stm: Piece) -> Hash {
-        let a = white.0;
-        let b = black.0;
+    pub fn new(black: BitBoard, white: BitBoard, stm: Piece) -> Hash {
+        let a = black.0;
+        let b = white.0;
 
         // Currently, an 2^-63-almost delta universal hash function, based on
         // https://eprint.iacr.org/2011/116.pdf by Long Hoang Nguyen and Andrew

--- a/ataxx/src/lib.rs
+++ b/ataxx/src/lib.rs
@@ -3,6 +3,7 @@
 // without their parent namespace.
 pub use self::bitboard::*;
 pub use self::hash::*;
+pub use self::perft::*;
 pub use self::piece::*;
 pub use self::position::*;
 pub use self::r#move::*;
@@ -12,6 +13,7 @@ pub use self::square::*;
 mod bitboard;
 mod hash;
 mod r#move;
+mod perft;
 mod piece;
 mod position;
 mod square;

--- a/ataxx/src/lib.rs
+++ b/ataxx/src/lib.rs
@@ -3,17 +3,17 @@
 // without their parent namespace.
 pub use self::bitboard::*;
 pub use self::board::*;
-pub use self::color::*;
 pub use self::hash::*;
+pub use self::piece::*;
 pub use self::r#move::*;
 pub use self::square::*;
 
 // Non-namespaced modules.
 mod bitboard;
 mod board;
-mod color;
 mod hash;
 mod r#move;
+mod piece;
 mod square;
 
 // Private modules.

--- a/ataxx/src/lib.rs
+++ b/ataxx/src/lib.rs
@@ -2,18 +2,18 @@
 // modules public, so they can be accessed
 // without their parent namespace.
 pub use self::bitboard::*;
-pub use self::board::*;
 pub use self::hash::*;
 pub use self::piece::*;
+pub use self::position::*;
 pub use self::r#move::*;
 pub use self::square::*;
 
 // Non-namespaced modules.
 mod bitboard;
-mod board;
 mod hash;
 mod r#move;
 mod piece;
+mod position;
 mod square;
 
 // Private modules.

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -44,7 +44,7 @@ impl Move {
     /// use std::str::FromStr;
     ///
     /// let board = Board::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
-    /// let old_pos = board.position();
+    /// let old_pos = board.clone();
     /// let new_pos = old_pos.after_move(Move::PASS);
     ///
     /// assert_eq!(old_pos.bitboard(Color::Black), new_pos.bitboard(Color::Black));

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -47,8 +47,8 @@ impl Move {
     /// let old_pos = board.clone();
     /// let new_pos = old_pos.after_move(Move::PASS);
     ///
-    /// assert_eq!(old_pos.bitboard(Color::Black), new_pos.bitboard(Color::Black));
-    /// assert_eq!(old_pos.bitboard(Color::White), new_pos.bitboard(Color::White));
+    /// assert_eq!(old_pos.bitboard(Piece::Black), new_pos.bitboard(Piece::Black));
+    /// assert_eq!(old_pos.bitboard(Piece::White), new_pos.bitboard(Piece::White));
     /// assert_eq!(old_pos.side_to_move, !new_pos.side_to_move);
     /// ```
     pub const PASS: Move = Move(1 << 15 | 1 << 14);

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 
 use thiserror::Error;
 
-use crate::Square;
+use crate::{Square, SquareParseError};
 
 /// Move represents an Ataxx move which can be played on the Board.
 #[derive(Copy, Clone, PartialEq, Eq, Default)]
@@ -143,9 +143,7 @@ pub enum MoveParseError {
     #[error("length of move string should be 2 or 4, not {0}")]
     BadLength(usize),
     #[error("bad source square string \"{0}\"")]
-    BadSourceSquare(String),
-    #[error("bad target square string \"{0}\"")]
-    BadTargetSquare(String),
+    BadSquare(#[from] SquareParseError),
 }
 
 impl FromStr for Move {
@@ -179,20 +177,14 @@ impl FromStr for Move {
         }
 
         let source = &s[..2];
-        let source = match Square::from_str(source) {
-            Ok(sq) => sq,
-            Err(_err) => return Err(MoveParseError::BadSourceSquare(source.to_string())),
-        };
+        let source = Square::from_str(source)?;
 
         if s.len() < 4 {
             return Ok(Move::new_single(source));
         }
 
         let target = &s[2..];
-        let target = match Square::from_str(target) {
-            Ok(sq) => sq,
-            Err(_err) => return Err(MoveParseError::BadTargetSquare(target.to_string())),
-        };
+        let target = Square::from_str(target)?;
 
         Ok(Move::new(source, target))
     }

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -44,7 +44,7 @@ impl Move {
     /// use std::str::FromStr;
     ///
     /// let old_pos = Position::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
-    /// let new_pos = old_pos.after_move(Move::PASS);
+    /// let new_pos = old_pos.after_move::<true>(Move::PASS);
     ///
     /// assert_eq!(old_pos.bitboard(Piece::Black), new_pos.bitboard(Piece::Black));
     /// assert_eq!(old_pos.bitboard(Piece::White), new_pos.bitboard(Piece::White));

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -100,9 +100,9 @@ impl Move {
     #[inline(always)]
     #[rustfmt::skip]
     pub fn source(self) -> Square {
-        Square::try_from(
+        Square::unsafe_from(
             (self.0 >> Move::SOURCE_OFFSET) & Move::SOURCE_MASK
-        ).unwrap()
+        )
     }
 
     /// Target returns the target Square of the moving piece.
@@ -116,9 +116,9 @@ impl Move {
     #[inline(always)]
     #[rustfmt::skip]
     pub fn target(self) -> Square {
-        Square::try_from(
+        Square::unsafe_from(
             (self.0 >> Move::TARGET_OFFSET) & Move::TARGET_MASK
-        ).unwrap()
+        )
     }
 
     /// is_single checks if the given Move is singular in nature. The result of this

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -152,10 +152,11 @@ impl FromStr for Move {
     type Err = MoveParseError;
 
     /// from_str converts the given string representation of a Move into a [Move].
-    /// The formats supported are '0000' for a [Move::PASS], <target> for a singular
-    /// Move, and <source><target> for a jump Move. For how <source> and <target>
-    /// are parsed, take a look at [`Square::FromStr`](Square::from_str). This
-    /// function can be treated as the inverse of [`Move::Display`].
+    /// The formats supported are '0000' for a [Move::PASS], `<target>` for a
+    /// singular Move, and `<source><target>` for a jump Move. For how `<source>`
+    /// and `<target>` are parsed, take a look at
+    /// [`Square::FromStr`](Square::from_str). This function can be treated as the
+    /// inverse of the [`fmt::Display`] trait for [Move].
     /// ```
     /// use ataxx::*;
     /// use std::str::FromStr;
@@ -239,8 +240,8 @@ impl fmt::Debug for Move {
 
 /// MoveStore is a trait implemented by types which are able to store [Move]s inside
 /// themselves and are thus usable in move-generation methods in
-/// [Board](super::Board) like
-/// [`Board::generate_moves_into<T>`](super::Board::generate_moves_into<T>).
+/// [Position](super::Position) like
+/// [`Position::generate_moves_into<T>`](super::Position::generate_moves_into<T>).
 pub trait MoveStore {
     /// push adds the given Move to the MoveStore.
     fn push(&mut self, m: Move);

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -15,6 +15,8 @@ use std::fmt;
 use std::mem::MaybeUninit;
 use std::str::FromStr;
 
+use thiserror::Error;
+
 use crate::Square;
 
 /// Move represents an Ataxx move which can be played on the Board.
@@ -137,10 +139,13 @@ impl Move {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum MoveParseError {
+    #[error("length of move string should be 2 or 4, not {0}")]
     BadLength(usize),
+    #[error("bad source square string \"{0}\"")]
     BadSourceSquare(String),
+    #[error("bad target square string \"{0}\"")]
     BadTargetSquare(String),
 }
 

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -43,8 +43,7 @@ impl Move {
     /// use ataxx::*;
     /// use std::str::FromStr;
     ///
-    /// let board = Board::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
-    /// let old_pos = board.clone();
+    /// let old_pos = Position::from_str("x5o/7/7/7/7/7/o5x x 0 1").unwrap();
     /// let new_pos = old_pos.after_move(Move::PASS);
     ///
     /// assert_eq!(old_pos.bitboard(Piece::Black), new_pos.bitboard(Piece::Black));

--- a/ataxx/src/move.rs
+++ b/ataxx/src/move.rs
@@ -290,14 +290,6 @@ impl MoveList {
         // the MoveList can only be increased by pushing Moves into it.
         unsafe { self.list[n].assume_init() }
     }
-
-    /// iter returns an [Iterator] which iterates over the moves in the MoveList.
-    pub fn iter(&self) -> MoveListIterator {
-        MoveListIterator {
-            list: self,
-            current: 0,
-        }
-    }
 }
 
 // Implement the MoveStore trait to allow usage in move-generation functions.
@@ -342,13 +334,27 @@ impl MoveStore for MoveList {
     }
 }
 
+impl IntoIterator for MoveList {
+    type Item = Move;
+    type IntoIter = MoveListIterator;
+
+    /// into_iter automatically converts a [MoveList] into an iterator when
+    /// necessary, like inside a for loop.
+    fn into_iter(self) -> Self::IntoIter {
+        MoveListIterator {
+            list: self,
+            current: 0,
+        }
+    }
+}
+
 /// MoveListIterator implements an [Iterator] for a [MoveList].
-pub struct MoveListIterator<'a> {
-    list: &'a MoveList,
+pub struct MoveListIterator {
+    list: MoveList,
     current: usize,
 }
 
-impl Iterator for MoveListIterator<'_> {
+impl Iterator for MoveListIterator {
     type Item = Move;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/ataxx/src/perft.rs
+++ b/ataxx/src/perft.rs
@@ -1,4 +1,4 @@
-use crate::Position;
+use crate::{MoveStore, Position};
 
 /// perft is a function to walk the move generation tree of strictly legal moves
 /// to count all the leaf nodes of a certain depth.
@@ -26,7 +26,13 @@ pub fn perft<const SPLIT: bool, const BULK: bool>(position: Position, depth: u8)
     let mut nodes: u64 = 0;
     let movelist = position.generate_moves();
 
-    for m in movelist {
+    // MoveList implements IntoIterator, so it should be possible to use it
+    // directly in the for loop, but manual iterations seems to be faster.
+    for i in 0..movelist.len() {
+        let m = movelist.at(i);
+
+        // Find the next position without updating the Hash, which is unnecessary
+        // inside perft given uniquely identifying positions here is unnecessary.
         let new_position = position.after_move::<false>(m);
 
         // Spilt should always be disabled for child perft calls, and a child perft

--- a/ataxx/src/perft.rs
+++ b/ataxx/src/perft.rs
@@ -26,7 +26,7 @@ pub fn perft<const SPLIT: bool, const BULK: bool>(position: Position, depth: u8)
     let mut nodes: u64 = 0;
     let movelist = position.generate_moves();
 
-    for m in movelist.iter() {
+    for m in movelist {
         let new_position = position.after_move(m);
 
         // Spilt should always be disabled for child perft calls, and a child perft

--- a/ataxx/src/perft.rs
+++ b/ataxx/src/perft.rs
@@ -1,0 +1,46 @@
+use crate::Position;
+
+/// perft is a function to walk the move generation tree of strictly legal moves
+/// to count all the leaf nodes of a certain depth.
+///
+/// If `SPLIT` is set to `true`, the perft value contributed by each legal move
+/// in the current position is displayed separately. If `BULK` is set to `true`,
+/// a trick known as bulk-counting is used, which makes it significantly faster.
+///
+/// In perft, nodes are only counted at the end after the last make-move. Thus
+/// "higher" terminal nodes (e.g. mate or stalemate) are not counted, instead
+/// the number of move paths of a certain depth. Perft ignores draws by
+/// repetition, by the fifty-move rule and by insufficient material.
+pub fn perft<const SPLIT: bool, const BULK: bool>(position: Position, depth: u8) -> u64 {
+    // Bulk counting if enabled. Instead of calling make move and perft for each
+    // move at depth 1, just return the number of legal moves, which is equivalent.
+    if BULK && depth == 1 {
+        return position.count_moves() as u64;
+    }
+
+    // At depth 0, perft is defined to be 1.
+    if depth == 0 {
+        return 1;
+    }
+
+    let mut nodes: u64 = 0;
+    let movelist = position.generate_moves();
+
+    for m in movelist.iter() {
+        let new_position = position.after_move(m);
+
+        // Spilt should always be disabled for child perft calls, and a child perft
+        // should have the same bulk counting behavior as the parent perft call.
+        let new_nodes = perft::<false, BULK>(new_position, depth - 1);
+
+        // If spilt perft is enabled, print the nodes added due to this move.
+        if SPLIT {
+            println!("{}: {}", m, new_nodes);
+        }
+
+        // Add the new node count to the cumulative total.
+        nodes += new_nodes;
+    }
+
+    nodes
+}

--- a/ataxx/src/perft.rs
+++ b/ataxx/src/perft.rs
@@ -27,7 +27,7 @@ pub fn perft<const SPLIT: bool, const BULK: bool>(position: Position, depth: u8)
     let movelist = position.generate_moves();
 
     for m in movelist {
-        let new_position = position.after_move(m);
+        let new_position = position.after_move::<false>(m);
 
         // Spilt should always be disabled for child perft calls, and a child perft
         // should have the same bulk counting behavior as the parent perft call.

--- a/ataxx/src/piece.rs
+++ b/ataxx/src/piece.rs
@@ -23,12 +23,12 @@ use thiserror::Error;
 use crate::type_macros;
 
 /// Piece represents all the possible pieces that an ataxx piece can have,
-/// specifically White, Black, and None(no Piece/no piece).
+/// specifically Black, White, and None(no Piece/no piece).
 #[derive(Copy, Clone, PartialEq, Eq, Default, FromPrimitive)]
 pub enum Piece {
-    White,
     Black,
-    Gap,
+    White,
+    Block,
     #[default]
     None,
 }
@@ -81,7 +81,7 @@ impl fmt::Display for Piece {
             match *self {
                 Self::Black => "x",
                 Self::White => "o",
-                Self::Gap => "■",
+                Self::Block => "■",
                 Self::None => ".",
             }
         )
@@ -111,6 +111,7 @@ impl FromStr for Piece {
         match s {
             "x" | "X" | "b" | "B" => Ok(Piece::Black),
             "o" | "O" | "w" | "W" => Ok(Piece::White),
+            "-" => Ok(Piece::Block),
             _ => Err(PieceParseError::StringFormatInvalid(s.to_string())),
         }
     }

--- a/ataxx/src/piece.rs
+++ b/ataxx/src/piece.rs
@@ -35,7 +35,7 @@ pub enum Piece {
 
 // Implement conversions from numerical types.
 type_macros::impl_from_integer_for_enum! {
-    for Piece:
+    for Piece Piece::N + 1 =>
 
     // unsigned integers
     usize, Piece::from_usize;
@@ -59,7 +59,7 @@ impl ops::Not for Piece {
     /// not implements the not unary operator (!) which switches the current Piece
     /// to its opposite, i.e. [`Piece::Black`] to [`Piece::White`] and vice versa.
     fn not(self) -> Self::Output {
-        Piece::try_from(self as usize ^ 1).unwrap()
+        Piece::unsafe_from(self as usize ^ 1)
     }
 }
 

--- a/ataxx/src/piece.rs
+++ b/ataxx/src/piece.rs
@@ -28,6 +28,7 @@ use crate::type_macros;
 pub enum Piece {
     White,
     Black,
+    Gap,
     #[default]
     None,
 }
@@ -49,7 +50,7 @@ type_macros::impl_from_integer_for_enum! {
 
 impl Piece {
     /// N is the number of possible Pieces, excluding None.
-    pub const N: usize = 2;
+    pub const N: usize = 3;
 }
 
 impl ops::Not for Piece {
@@ -80,7 +81,8 @@ impl fmt::Display for Piece {
             match *self {
                 Self::Black => "x",
                 Self::White => "o",
-                Self::None => "-",
+                Self::Gap => "■",
+                Self::None => ".",
             }
         )
     }

--- a/ataxx/src/piece.rs
+++ b/ataxx/src/piece.rs
@@ -22,10 +22,10 @@ use thiserror::Error;
 
 use crate::type_macros;
 
-/// Color represents all the possible colors that an ataxx piece can have,
-/// specifically White, Black, and None(no Color/no piece).
+/// Piece represents all the possible pieces that an ataxx piece can have,
+/// specifically White, Black, and None(no Piece/no piece).
 #[derive(Copy, Clone, PartialEq, Eq, Default, FromPrimitive)]
-pub enum Color {
+pub enum Piece {
     White,
     Black,
     #[default]
@@ -34,45 +34,45 @@ pub enum Color {
 
 // Implement conversions from numerical types.
 type_macros::impl_from_integer_for_enum! {
-    for Color:
+    for Piece:
 
     // unsigned integers
-    usize, Color::from_usize;
-    u8, Color::from_u8; u16, Color::from_u16;
-    u32, Color::from_u32; u64, Color::from_u64;
+    usize, Piece::from_usize;
+    u8, Piece::from_u8; u16, Piece::from_u16;
+    u32, Piece::from_u32; u64, Piece::from_u64;
 
     // signed integers
-    isize, Color::from_isize;
-    i8, Color::from_i8; i16, Color::from_i16;
-    i32, Color::from_i32; i64, Color::from_i64;
+    isize, Piece::from_isize;
+    i8, Piece::from_i8; i16, Piece::from_i16;
+    i32, Piece::from_i32; i64, Piece::from_i64;
 }
 
-impl Color {
-    /// N is the number of possible Colors, excluding None.
+impl Piece {
+    /// N is the number of possible Pieces, excluding None.
     pub const N: usize = 2;
 }
 
-impl ops::Not for Color {
-    type Output = Color;
+impl ops::Not for Piece {
+    type Output = Piece;
 
-    /// not implements the not unary operator (!) which switches the current Color
-    /// to its opposite, i.e. [`Color::Black`] to [`Color::White`] and vice versa.
+    /// not implements the not unary operator (!) which switches the current Piece
+    /// to its opposite, i.e. [`Piece::Black`] to [`Piece::White`] and vice versa.
     fn not(self) -> Self::Output {
-        Color::try_from(self as usize ^ 1).unwrap()
+        Piece::try_from(self as usize ^ 1).unwrap()
     }
 }
 
 #[derive(Error, Debug)]
-pub enum ColorParseError {
-    #[error("color identifier string has more than 1 character")]
+pub enum PieceParseError {
+    #[error("piece identifier string has more than 1 character")]
     StringTooLong,
-    #[error("unknown color identifier '{0}'")]
+    #[error("unknown piece identifier '{0}'")]
     StringFormatInvalid(String),
 }
 
-impl fmt::Display for Color {
-    /// Implements displaying the Color in a human-readable form. [`Color::Black`]
-    /// is formatted as `x` and [`Color::White`] is formatted as `o`.
+impl fmt::Display for Piece {
+    /// Implements displaying the Piece in a human-readable form. [`Piece::Black`]
+    /// is formatted as `x` and [`Piece::White`] is formatted as `o`.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(
             f,
@@ -86,30 +86,30 @@ impl fmt::Display for Color {
     }
 }
 
-impl fmt::Debug for Color {
-    /// Debug implements debug printing of a Color in a human-readable form. It uses
-    /// `Color::Display` under the hood to format and print the Color.
+impl fmt::Debug for Piece {
+    /// Debug implements debug printing of a Piece in a human-readable form. It uses
+    /// `Piece::Display` under the hood to format and print the Piece.
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-impl FromStr for Color {
-    type Err = ColorParseError;
+impl FromStr for Piece {
+    type Err = PieceParseError;
 
     /// from_str converts the given human-readable string into its corresponding
-    /// [`Color`]. `x`, `X`, `b`, `B` are parsed as [`Color::Black`] and `o`, `O`,
-    /// `w`, `W` are parsed as [`Color::White`]. Best practice is to use `x` and `o`
+    /// [`Piece`]. `x`, `X`, `b`, `B` are parsed as [`Piece::Black`] and `o`, `O`,
+    /// `w`, `W` are parsed as [`Piece::White`]. Best practice is to use `x` and `o`
     /// respectively for black and white.
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if s.len() != 1 {
-            return Err(ColorParseError::StringTooLong);
+            return Err(PieceParseError::StringTooLong);
         }
 
         match s {
-            "x" | "X" | "b" | "B" => Ok(Color::Black),
-            "o" | "O" | "w" | "W" => Ok(Color::White),
-            _ => Err(ColorParseError::StringFormatInvalid(s.to_string())),
+            "x" | "X" | "b" | "B" => Ok(Piece::Black),
+            "o" | "O" | "w" | "W" => Ok(Piece::White),
+            _ => Err(PieceParseError::StringFormatInvalid(s.to_string())),
         }
     }
 }

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -237,7 +237,7 @@ impl Position {
         if m == Move::PASS {
             return Position {
                 bitboards: self.bitboards,
-                checksum: Hash(!self.checksum.0),
+                checksum: !self.checksum,
                 side_to_move: !self.side_to_move,
                 ply_count: self.ply_count + 1,
                 half_move_clock: self.half_move_clock + 1,

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -230,14 +230,14 @@ impl Position {
     ///
     /// assert_eq!(pos.after_move(mov).checksum, new_pos.checksum);
     /// ```
-    pub fn after_move(&self, m: Move) -> Position {
+    pub fn after_move<const UPDATE_HASH: bool>(&self, m: Move) -> Position {
         let stm = self.side_to_move;
 
         // A pass move is a do nothing move; just change the side to move.
         if m == Move::PASS {
             return Position {
                 bitboards: self.bitboards,
-                checksum: !self.checksum,
+                checksum: if UPDATE_HASH { !self.checksum } else { Hash(0) },
                 side_to_move: !self.side_to_move,
                 ply_count: self.ply_count + 1,
                 half_move_clock: self.half_move_clock + 1,
@@ -269,7 +269,11 @@ impl Position {
 
         Position {
             bitboards: [black, white, self.bitboard(Piece::Block)],
-            checksum: Hash::new(black, white, !stm),
+            checksum: if UPDATE_HASH {
+                Hash::new(black, white, !stm)
+            } else {
+                Hash(0)
+            },
             side_to_move: !stm,
             ply_count: self.ply_count + 1,
             half_move_clock,

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -228,7 +228,7 @@ impl Position {
     ///
     /// let mov = Move::new_single(Square::B7);
     ///
-    /// assert_eq!(pos.after_move(mov)::<true>.checksum, new_pos.checksum);
+    /// assert_eq!(pos.after_move::<true>(mov).checksum, new_pos.checksum);
     /// ```
     pub fn after_move<const UPDATE_HASH: bool>(&self, m: Move) -> Position {
         let stm = self.side_to_move;

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -248,22 +248,17 @@ impl Position {
         let xtm_pieces = self.bitboard(!stm);
 
         let captured = BitBoard::single(m.target()) & xtm_pieces;
+        let from_to = BitBoard::from(m.target()) | BitBoard::from(m.source());
 
         // Move the captured pieces from xtm to stm.
         let new_xtm = xtm_pieces ^ captured;
-        let new_stm = stm_pieces ^ captured;
-
-        // Add a stm piece to the target square.
-        let mut new_stm = new_stm | BitBoard::from(m.target());
+        let new_stm = stm_pieces ^ captured ^ from_to;
 
         // Reset half move clock on a singular move.
-        let mut half_move_clock = 0;
-
-        // Remove the piece from the source square if the move is non-singular.
-        if !m.is_single() {
-            new_stm ^= BitBoard::from(m.source());
-            // Jump move, so don't reset half move clock.
-            half_move_clock = self.half_move_clock + 1;
+        let half_move_clock = if m.is_single() {
+            0
+        } else {
+            self.half_move_clock + 1
         };
 
         let (white, black) = if stm == Piece::White {

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -27,8 +27,9 @@ use crate::{
     PieceParseError,
 };
 
-/// Position represents the snapshot of an Ataxx Board, the state of the Board
-/// at a single point in time. It is the functional backend of the [Board] type.
+/// Position represents the snapshot of an Ataxx Board, the state of the an
+/// ataxx game at a single point in time. It also provides all of the methods
+/// necessary to manipulate such a snapshot.
 #[derive(Copy, Clone)]
 pub struct Position {
     /// bitboards stores [BitBoard]s for the piece configuration of each [Piece].
@@ -162,7 +163,7 @@ impl Position {
     }
 
     /// winner returns the Piece which has won the game. It returns [`Piece::None`]
-    /// if the game is a draw. If [`Board::is_game_over`] is false, then the
+    /// if the game is a draw. If [`Position::is_game_over`] is false, then the
     /// behavior of this function is undefined.
     /// ```
     /// use ataxx::*;

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -233,11 +233,21 @@ impl Position {
     pub fn after_move<const UPDATE_HASH: bool>(&self, m: Move) -> Position {
         let stm = self.side_to_move;
 
+        macro_rules! update_hash {
+            ($e:expr) => {
+                if UPDATE_HASH {
+                    $e
+                } else {
+                    Hash::ZERO
+                }
+            };
+        }
+
         // A pass move is a do nothing move; just change the side to move.
         if m == Move::PASS {
             return Position {
                 bitboards: self.bitboards,
-                checksum: if UPDATE_HASH { !self.checksum } else { Hash(0) },
+                checksum: update_hash!(!self.checksum),
                 side_to_move: !self.side_to_move,
                 ply_count: self.ply_count + 1,
                 half_move_clock: self.half_move_clock + 1,
@@ -269,11 +279,7 @@ impl Position {
 
         Position {
             bitboards: [black, white, self.bitboard(Piece::Block)],
-            checksum: if UPDATE_HASH {
-                Hash::new(black, white, !stm)
-            } else {
-                Hash(0)
-            },
+            checksum: update_hash!(Hash::new(black, white, !stm)),
             side_to_move: !stm,
             ply_count: self.ply_count + 1,
             half_move_clock,

--- a/ataxx/src/position.rs
+++ b/ataxx/src/position.rs
@@ -228,7 +228,7 @@ impl Position {
     ///
     /// let mov = Move::new_single(Square::B7);
     ///
-    /// assert_eq!(pos.after_move(mov).checksum, new_pos.checksum);
+    /// assert_eq!(pos.after_move(mov)::<true>.checksum, new_pos.checksum);
     /// ```
     pub fn after_move<const UPDATE_HASH: bool>(&self, m: Move) -> Position {
         let stm = self.side_to_move;

--- a/ataxx/src/square.rs
+++ b/ataxx/src/square.rs
@@ -17,6 +17,7 @@ use std::str::FromStr;
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
 use strum_macros::EnumIter;
+use thiserror::Error;
 
 use crate::type_macros;
 
@@ -113,11 +114,14 @@ impl Square {
 
 /// SquareParseError represents the various errors that can
 /// be encountered while parsing a given string into a Square.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum SquareParseError {
+    #[error("wrong square string size")]
     WrongStringSize,
-    FileParseError(FileParseError),
-    RankParseError(RankParseError),
+    #[error("{0}")]
+    FileParseError(#[from] FileParseError),
+    #[error("{0}")]
+    RankParseError(#[from] RankParseError),
 }
 
 impl FromStr for Square {
@@ -138,17 +142,8 @@ impl FromStr for Square {
             return Err(SquareParseError::WrongStringSize);
         }
 
-        // Parse the File specification.
-        let file = match File::from_str(&s[..=0]) {
-            Ok(file) => file,
-            Err(err) => return Err(SquareParseError::FileParseError(err)),
-        };
-
-        // Parse the Rank specification.
-        let rank = match Rank::from_str(&s[1..]) {
-            Ok(rank) => rank,
-            Err(err) => return Err(SquareParseError::RankParseError(err)),
-        };
+        let file = File::from_str(&s[..1])?; // Parse the File specification.
+        let rank = Rank::from_str(&s[1..])?; // Parse the Rank specification.
 
         Ok(Square::new(file, rank))
     }
@@ -213,9 +208,11 @@ impl File {
 
 /// FileParseError represents the various errors that can
 /// be encountered while parsing a given string into a File.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum FileParseError {
+    #[error("wrong string size for file identifier")]
     WrongStringSize,
+    #[error("invalid file identifier string")]
     InvalidFileString,
 }
 
@@ -305,9 +302,11 @@ impl Rank {
 
 /// RankParseError represents the various errors that can
 /// be encountered while parsing a given string into a Rank.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum RankParseError {
+    #[error("wrong string size for rank identifier")]
     WrongStringSize,
+    #[error("invalid rank identifier string")]
     InvalidRankString,
 }
 

--- a/ataxx/src/square.rs
+++ b/ataxx/src/square.rs
@@ -45,7 +45,7 @@ impl Square {
     /// assert_eq!(Square::new(File::A, Rank::First), Square::A1);
     /// ```
     pub fn new(file: File, rank: Rank) -> Square {
-        Square::try_from(rank as usize * File::N + file as usize).unwrap()
+        Square::unsafe_from(rank as usize * File::N + file as usize)
     }
 
     /// file returns the File of the current Square.
@@ -56,7 +56,7 @@ impl Square {
     /// ```
     #[inline(always)]
     pub fn file(self) -> File {
-        File::try_from(self as usize % File::N).unwrap()
+        File::unsafe_from(self as usize % File::N)
     }
 
     /// rank returns the Rank of the current Square.
@@ -67,7 +67,7 @@ impl Square {
     /// ```
     #[inline(always)]
     pub fn rank(self) -> Rank {
-        Rank::try_from(self as usize / File::N).unwrap()
+        Rank::unsafe_from(self as usize / File::N)
     }
 
     /// north returns the Square to the North of this one.
@@ -77,7 +77,7 @@ impl Square {
     /// assert_eq!(Square::D4.north(), Square::D5);
     /// ```
     pub fn north(self) -> Self {
-        Square::try_from(self as usize + File::N).unwrap()
+        Square::unsafe_from(self as usize + File::N)
     }
 
     /// south returns the Square to the South of this one.
@@ -87,7 +87,7 @@ impl Square {
     /// assert_eq!(Square::D4.south(), Square::D3);
     /// ```
     pub fn south(self) -> Self {
-        Square::try_from(self as usize - File::N).unwrap()
+        Square::unsafe_from(self as usize - File::N)
     }
 
     /// east returns the Square to the East of this one.
@@ -97,7 +97,7 @@ impl Square {
     /// assert_eq!(Square::D4.east(), Square::E4);
     /// ```
     pub fn east(self) -> Self {
-        Square::try_from(self as usize + 1).unwrap()
+        Square::unsafe_from(self as usize + 1)
     }
 
     /// west returns the Square to the West of this one.
@@ -107,7 +107,7 @@ impl Square {
     /// assert_eq!(Square::D4.west(), Square::C4);
     /// ```
     pub fn west(self) -> Self {
-        Square::try_from(self as usize - 1).unwrap()
+        Square::unsafe_from(self as usize - 1)
     }
 }
 
@@ -156,7 +156,7 @@ impl FromStr for Square {
 
 // Implement from and into traits for all primitive integer types.
 type_macros::impl_from_integer_for_enum! {
-    for Square:
+    for Square Square::N =>
 
     // Unsigned Integers.
     usize, Square::from_usize;
@@ -243,13 +243,13 @@ impl FromStr for File {
             return Err(FileParseError::InvalidFileString);
         }
 
-        Ok(File::try_from(ident - b'a').unwrap())
+        Ok(File::unsafe_from(ident - b'a'))
     }
 }
 
 // Implement from and into traits for all primitive integer types.
 type_macros::impl_from_integer_for_enum! {
-    for File:
+    for File File::N =>
 
     // Unsigned Integers.
     usize, File::from_usize;
@@ -336,13 +336,13 @@ impl FromStr for Rank {
             return Err(RankParseError::InvalidRankString);
         }
 
-        Ok(Rank::try_from(ident - b'1').unwrap())
+        Ok(Rank::unsafe_from(ident - b'1'))
     }
 }
 
 // Implement from and into traits for all primitive integer types.
 type_macros::impl_from_integer_for_enum! {
-    for Rank:
+    for Rank Rank::N =>
 
     // Unsigned Integers.
     usize, Rank::from_usize;

--- a/ataxx/src/type_macros.rs
+++ b/ataxx/src/type_macros.rs
@@ -1,7 +1,7 @@
 #[macro_export]
 #[doc(hidden)]
 macro_rules! impl_from_integer_for_enum {
-    (for $type:ident: $($num:ident, $fn:path;)*) => {$(
+    (for $type:ident $size:expr => $($num:ident, $fn:path;)*) => {$(
         impl TryFrom<$num> for $type {
             type Error = ();
             #[inline(always)]
@@ -19,7 +19,17 @@ macro_rules! impl_from_integer_for_enum {
                 number as Self
             }
         }
-    )*};
+    )*
+
+    impl $type {
+        #[inline(always)]
+        pub fn unsafe_from<T: num_traits::ToPrimitive>(number: T) -> Self {
+            debug_assert!(number.to_u64().unwrap() < $size as u64);
+            unsafe {
+                std::mem::transmute_copy(&number)
+            }
+        }
+    }};
 }
 
 pub use impl_from_integer_for_enum;

--- a/ataxx/tests/perft.rs
+++ b/ataxx/tests/perft.rs
@@ -1,0 +1,37 @@
+use ataxx::{perft, Position};
+use std::str::FromStr;
+
+macro_rules! perft_test {
+    ($name:ident $pos:literal $depth:literal $nodes:literal) => {
+        #[test]
+        fn $name() {
+            let position = Position::from_str($pos).unwrap();
+            assert_eq!(perft::<true, true>(position, $depth), $nodes)
+        }
+    };
+}
+
+// Tests taken from libataxx
+
+perft_test!(position_01_x "7/7/7/7/7/7/7 x 0 1" 4 0);
+perft_test!(position_01_o "7/7/7/7/7/7/7 o 0 1" 4 0);
+perft_test!(position_02_x "x5o/7/7/7/7/7/o5x x 0 1" 5 4752668);
+perft_test!(position_02_o "x5o/7/7/7/7/7/o5x o 0 1" 5 4752668);
+perft_test!(position_03_x "x5o/7/2-1-2/7/2-1-2/7/o5x x 0 1" 5 2266352);
+perft_test!(position_03_o "x5o/7/2-1-2/7/2-1-2/7/o5x o 0 1" 5 2266352);
+perft_test!(position_04_x "x5o/7/2-1-2/3-3/2-1-2/7/o5x x 0 1" 5 2114588);
+perft_test!(position_04_o "x5o/7/2-1-2/3-3/2-1-2/7/o5x o 0 1" 5 2114588);
+perft_test!(position_05_x "x5o/7/3-3/2-1-2/3-3/7/o5x x 0 1" 5 3639856);
+perft_test!(position_05_o "x5o/7/3-3/2-1-2/3-3/7/o5x o 0 1" 5 3639856);
+perft_test!(position_06_x "7/7/7/7/ooooooo/ooooooo/xxxxxxx x 0 1" 5 452980);
+perft_test!(position_06_o "7/7/7/7/ooooooo/ooooooo/xxxxxxx o 0 1" 4 452980);
+perft_test!(position_07_x "7/7/7/7/xxxxxxx/xxxxxxx/ooooooo x 0 1" 4 452980);
+perft_test!(position_07_o "7/7/7/7/xxxxxxx/xxxxxxx/ooooooo o 0 1" 5 452980);
+perft_test!(position_08_x "7/7/7/2x1o2/7/7/7 x 0 1" 5 4266992);
+perft_test!(position_08_o "7/7/7/2x1o2/7/7/7 o 0 1" 5 4266992);
+perft_test!(position_09_x "x5o/7/7/7/7/7/o5x x 100 1" 5 0);
+perft_test!(position_09_o "x5o/7/7/7/7/7/o5x o 100 1" 5 0);
+
+// TODO: Deal with disjointing blockers
+perft_test!(position_10_x "7/7/7/7/-------/-------/x5o x 0 1" 6 175); // 174 ^^
+perft_test!(position_10_o "7/7/7/7/-------/-------/x5o o 0 1" 6 175); // 174 ^^


### PR DESCRIPTION
# Changelog
- Added support for gaps (`Piece::Gap`).
- Removed the `Board` type, replaced by a better `Position`.
- Parsing a `Move` from a string (`FromStr` for `Move).
- Implemented `IntoIterator` for `MoveList`.
- Implemented a not operator (`!`) for `Hash`.
- Add the `UPDATE_HASH` template parameter to `after_move`
- Make the internal value of a `Hash` private.
- Implemented the `std::error::Error` trait for all errors.
- Added a perft function (`ataxx::perft`).
- Renamed `Color` to `Piece`.
- Add a bunch of tests to validate changes.