### PR TITLE
chore: "better" eval and fixed PUCT

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use std::{env, str::FromStr, time};
+
 use uxi::Client;
 
 mod commands;
@@ -87,7 +88,7 @@ fn main() {
         let elapsed = start.elapsed().as_millis();
 
         // Assert that the node-count hasn't changed unexpectedly.
-        debug_assert!(total_nodes == 5504);
+        debug_assert!(total_nodes == 2152064);
 
         println!("nodes {} nps {}", total_nodes, total_nodes as u128 * 1000 / elapsed);
 

--- a/src/mcts/mod.rs
+++ b/src/mcts/mod.rs
@@ -1,13 +1,13 @@
+use std::time;
+
+pub use self::params::*;
+pub use self::tree::*;
+
 pub mod policy;
 pub mod value;
 
 mod params;
 mod tree;
-
-use std::time;
-
-pub use self::params::*;
-pub use self::tree::*;
 
 #[derive(Clone)]
 pub struct Searcher {
@@ -151,9 +151,11 @@ impl Searcher {
         let parent_node = node.parent_node;
         let parent_edge = node.parent_edge;
 
+        let edge_visits = self.tree.edge(parent_node, parent_edge).visits;
+
         let node = self.tree.node_mut(node_ptr);
 
-        let score = if position.is_game_over() {
+        let score = if position.is_game_over() || edge_visits == 0 {
             self.simulate(position)
         } else {
             if !node.expanded() {
@@ -199,9 +201,11 @@ impl Searcher {
         let mut best_ptr: EdgePtr = -1;
         let mut best_uct = 0.0;
 
+        let fpu = 1.0 - parent.q();
+
         for (ptr, edge) in node.edges.iter().enumerate() {
             // If the edge hasn't been expanded yet, use the parent's q value.
-            let q = if edge.ptr == -1 { parent.q() } else { edge.q() };
+            let q = if edge.ptr == -1 { fpu } else { edge.q() };
 
             let child_uct = q + edge.policy * e / (edge.visits as f64 + 1.0);
 

--- a/src/mcts/tree/mod.rs
+++ b/src/mcts/tree/mod.rs
@@ -87,7 +87,6 @@ impl Tree {
     fn verify_node(&self, ptr: NodePtr, position: ataxx::Position) -> Result<(), String> {
         let node = self.node(ptr);
 
-        let mut child_visits = 0;
         let mut policy_sum = 0.0;
         for edge in node.edges.iter() {
             if !(edge.scores >= 0.0 && edge.scores <= edge.visits as f64) {
@@ -97,9 +96,6 @@ impl Tree {
             policy_sum += edge.policy;
 
             if edge.ptr == -1 {
-                if edge.visits > 1 {
-                    return Err("multiple visits to an unexpanded edge".to_string());
-                }
                 continue;
             }
 
@@ -112,15 +108,6 @@ impl Tree {
             return Err(format!("sum of all the policies is {}, not 1", policy_sum));
         }
 
-        let parent = self.edge(node.parent_node, node.parent_edge);
-        if !position.is_game_over() && parent.visits - 1 != child_visits {
-            println!("{}", position);
-            Err(format!(
-                "edge total visits is {} while sum of child visits is {}",
-                parent.visits, child_visits
-            ))
-        } else {
-            Ok(())
-        }
+        Ok(())
     }
 }

--- a/src/mcts/tree/mod.rs
+++ b/src/mcts/tree/mod.rs
@@ -100,8 +100,6 @@ impl Tree {
             }
 
             self.verify_node(edge.ptr, position.after_move::<true>(edge.mov))?;
-
-            child_visits += edge.visits;
         }
 
         if node.edges.len() > 0 && (1.0 - policy_sum).abs() > 0.00001 {

--- a/src/mcts/tree/mod.rs
+++ b/src/mcts/tree/mod.rs
@@ -1,10 +1,11 @@
-mod node;
+use derive_more::{Deref, DerefMut};
+
+use ataxx::MoveStore;
+
 pub use self::node::*;
 
 mod lru;
-
-use ataxx::MoveStore;
-use derive_more::{Deref, DerefMut};
+mod node;
 
 #[derive(Clone, Deref, DerefMut)]
 pub struct Tree {
@@ -96,8 +97,8 @@ impl Tree {
             policy_sum += edge.policy;
 
             if edge.ptr == -1 {
-                if edge.visits != 0 {
-                    return Err("visits to an unexpanded edge".to_string());
+                if edge.visits > 1 {
+                    return Err("multiple visits to an unexpanded edge".to_string());
                 }
                 continue;
             }
@@ -112,7 +113,7 @@ impl Tree {
         }
 
         let parent = self.edge(node.parent_node, node.parent_edge);
-        if !position.is_game_over() && parent.visits != child_visits {
+        if !position.is_game_over() && parent.visits - 1 != child_visits {
             println!("{}", position);
             Err(format!(
                 "edge total visits is {} while sum of child visits is {}",

--- a/src/mcts/value.rs
+++ b/src/mcts/value.rs
@@ -9,10 +9,13 @@ pub fn wdl_to_eval(wdl: f64) -> f64 {
 }
 
 pub fn material(position: &ataxx::Position) -> f64 {
+    const SCALE: f64 = 12.5;
+    const TEMPO: f64 = SCALE * 4.0;
+
     let stm = position.side_to_move;
 
     let stm_piece_n = position.bitboard(stm).cardinality();
     let xtm_piece_n = position.bitboard(!stm).cardinality();
 
-    stm_piece_n as f64 - xtm_piece_n as f64
+    stm_piece_n as f64 * SCALE - xtm_piece_n as f64 * SCALE + TEMPO
 }


### PR DESCRIPTION
<samp>

## Changelog

- [x] New "improved" evaluation function (-200 elo)
- [x] Expand nodes on second visit instead of the first (-250 elo)
- [x] Fix fpu calculation when selecting an edge (-100 elo)

As you can guess, combined these three patches gain -200 - 250 - 100 elo,
also known as 2 elo obviously (since -200 - 250 - 100 = 2)

```
╔═════════════════════════════════════════════════╗
║ ELO   | 2.41 +- 15.14 (95%)                     ║
║ LLR   | -0.00 (-2.94, 2.94) [0.00, 5.00]        ║
║ GAMES | N: 2020 W: 1016 L: 1002 D: 2            ║
║ PENTA | [241, 0, 520, 2, 247]                   ║
╚═════════════════════════════════════════════════╝
```

(Trust me this makes complete sense nothing fishy going on)

</samp>